### PR TITLE
Add position estimation and validation scripts for indoor positioning…

### DIFF
--- a/Data Generation/DOA/DOA_envs.py
+++ b/Data Generation/DOA/DOA_envs.py
@@ -22,6 +22,10 @@ python3 "Data Generation/DOA/DOA_envs.py" --data-dir "generated_network_scenario
 python3 "Data Generation/DOA/DOA_envs.py" \
   --data-dir "Data Generation/generated_network_scenarios" \
   --carrier-frequency-hz 5500000000.0
+
+@author: Giuliana Emberson
+@date: 7th of May 2026
+
 """
 
 from __future__ import annotations

--- a/Data Generation/README.md
+++ b/Data Generation/README.md
@@ -4,3 +4,67 @@
 - fastparquet (parquet columnar data storage format)
 - pyarrow (parquet columnar data storage format)
 - renovation (floorplan generation)
+
+## Pipeline
+
+The data-generation stage is split into five steps:
+
+1. Generate network scenarios, floor plans, targets, and shared antenna-target
+   links:
+
+```bash
+python3 "Data Generation/create_network_envs.py" --count 1 --seed 7 --output-dir "generated_network_scenarios"
+```
+
+2. Generate method-specific RSSI, TDOA, and DOA/AOA measurements:
+
+```bash
+python3 "Data Generation/RSSI/RSSI_envs.py" --data-dir "generated_network_scenarios" --seed 7
+python3 "Data Generation/TDOA/TDOA_envs.py" --data-dir "generated_network_scenarios" --seed 7
+python3 "Data Generation/DOA/DOA_envs.py" --data-dir "generated_network_scenarios" --seed 7
+```
+
+3. Estimate target positions using conventional RSSI, TDOA, and DOA/AOA
+   methods:
+
+```bash
+python3 "Data Generation/position_estimation.py" --data-dir "generated_network_scenarios"
+```
+
+4. Build the labelled ML dataset:
+
+```bash
+python3 "Data Generation/create_ml_dataset.py" --data-dir "generated_network_scenarios"
+```
+
+5. Validate that table counts, labels, measurements, estimates, and ML rows are
+   consistent:
+
+```bash
+python3 "Data Generation/validate_generation_outputs.py" --data-dir "generated_network_scenarios"
+```
+
+## Output Tables
+
+- `env_summary.parquet`: one row per scenario.
+- `antennas.parquet`: antenna positions and coverage radius.
+- `humans.parquet`: generated human obstacles.
+- `floor_plan_elements.parquet`: wall, door, and window geometry.
+- `grid_cells.parquet`: all generated target-grid cells.
+- `targets.parquet`: valid target positions and ground-truth labels.
+- `links.parquet`: one row per antenna-target pair with distance and LOS/NLOS
+  geometry.
+- `links_rssi.parquet`: RSSI/path-loss measurements per antenna-target link.
+- `links_tdoa.parquet`: TDOA measurements per target and non-reference antenna.
+- `links_doa.parquet`: DOA/AOA bearing measurements per antenna-target link.
+- `position_estimates.parquet`: one row per target with conventional RSSI,
+  TDOA, and DOA/AOA `(x, y)` estimates and error metrics.
+- `ml_dataset.parquet`: one labelled row per target for the ML pipeline.
+
+## Attenuation Scope
+
+The current implementation uses floor-plan geometry to classify links as LOS or
+NLOS and to count wall and human blockers. RSSI can apply uniform wall and human
+attenuation through `--wall-loss-db` and `--human-loss-db`; by default these are
+`0.0`, so no additional obstacle attenuation is applied. Material-specific
+attenuation coefficients are not currently modelled.

--- a/Data Generation/RSSI/RSSI_envs.py
+++ b/Data Generation/RSSI/RSSI_envs.py
@@ -22,6 +22,10 @@ python3 "Data Generation/RSSI/RSSI_envs.py" \
   --data-dir "Data Generation/generated_network_scenarios" \
   --tx-power-dbm 20.0 \
   --tx-gain-dbi 3.0
+  
+@author: Giuliana Emberson
+@date: 7th of May 2026
+
 """
 
 from __future__ import annotations
@@ -187,6 +191,7 @@ def build_rssi_base_table(
     - tx_power_dbm
     - tx_gain_dbi
     - rx_gain_dbi
+    - reference_distance_m
     - initial_signal_strength_dbm
     - wall_attenuation_db
     - human_attenuation_db
@@ -222,6 +227,7 @@ def build_rssi_base_table(
     rssi_df["tx_power_dbm"] = float(tx_power_dbm)
     rssi_df["tx_gain_dbi"] = float(tx_gain_dbi)
     rssi_df["rx_gain_dbi"] = float(rx_gain_dbi)
+    rssi_df["reference_distance_m"] = float(reference_distance_m)
 
     rssi_df["initial_signal_strength_dbm"] = _reference_rssi_dbm_from_freq(
         freq_mhz=rssi_df["freq_mhz"],
@@ -280,6 +286,7 @@ def build_rssi_base_table(
         "tx_power_dbm",
         "tx_gain_dbi",
         "rx_gain_dbi",
+        "reference_distance_m",
         "initial_signal_strength_dbm",
         "wall_attenuation_db",
         "human_attenuation_db",

--- a/Data Generation/TDOA/TDOA_envs.py
+++ b/Data Generation/TDOA/TDOA_envs.py
@@ -21,6 +21,10 @@ python3 "Data Generation/TDOA/TDOA_envs.py" --data-dir "generated_network_scenar
 python3 "Data Generation/TDOA/TDOA_envs.py" \
   --data-dir "Data Generation/generated_network_scenarios" \
   --propagation-speed-m-per-s 299792458.0
+
+@author: Giuliana Emberson
+@date: 7th of May 2026
+
 """
 
 from __future__ import annotations

--- a/Data Generation/create_ml_dataset.py
+++ b/Data Generation/create_ml_dataset.py
@@ -1,0 +1,396 @@
+"""
+LABELLED ML DATASET BUILDER
+---------------------------
+
+Construct one supervised-learning row per scenario-target pair by merging:
+- scenario/environment features
+- antenna-layout summaries
+- shared link geometry summaries
+- RSSI, TDOA, and DOA/AOA measurement summaries
+- conventional RSSI/TDOA/DOA position estimates
+
+Input tables:
+- env_summary.parquet
+- antennas.parquet
+- links.parquet
+- links_rssi.parquet
+- links_tdoa.parquet
+- links_doa.parquet
+- position_estimates.parquet
+
+Output table:
+- ml_dataset.parquet by default
+
+Usage examples:
+python3 "Data Generation/create_ml_dataset.py" --data-dir "generated_network_scenarios"
+python3 "Data Generation/create_ml_dataset.py" \
+  --data-dir "Data Generation/generated_network_scenarios" \
+  --output "Data Generation/generated_network_scenarios/ml_dataset.parquet"
+
+@author: Giuliana Emberson
+@date: 7th of May 2026
+
+"""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+from typing import Iterable, Union
+import numpy as np
+import pandas as pd
+
+
+KEY_COLUMNS = ["scenario_id", "target_id"]
+
+
+def _require_columns(df: pd.DataFrame, required: Iterable[str], table_name: str) -> None:
+    missing = set(required).difference(df.columns)
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(f"{table_name} is missing required columns: {missing_list}")
+
+
+def _read_table(data_dir: Union[str, Path], table_name: str, required: Iterable[str]) -> pd.DataFrame:
+    path = Path(data_dir) / f"{table_name}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Missing {path}. Run the corresponding data-generation stage first."
+        )
+    df = pd.read_parquet(path)
+    _require_columns(df, required, f"{table_name}.parquet")
+    return df
+
+
+def _std_or_zero(series: pd.Series) -> float:
+    value = series.std()
+    if pd.isna(value):
+        return 0.0
+    return float(value)
+
+
+def _scenario_features(env_summary_df: pd.DataFrame) -> pd.DataFrame:
+    preferred_cols = [
+        "scenario_id",
+        "seed",
+        "area",
+        "env_type",
+        "width",
+        "height",
+        "x_domain_min",
+        "x_domain_max",
+        "y_range_min",
+        "y_range_max",
+        "antenna_count",
+        "human_count",
+        "floor_plan_room_count",
+        "floor_plan_patio_count",
+        "floor_plan_element_count",
+        "target_count",
+        "grid_cell_count",
+        "valid_grid_cell_count",
+        "target_grid_rows",
+        "target_grid_cols",
+        "target_requested_max_cell_size",
+        "target_cell_width",
+        "target_cell_height",
+        "link_count",
+    ]
+    available_cols = [column for column in preferred_cols if column in env_summary_df.columns]
+    scenario_df = env_summary_df[available_cols].drop_duplicates().copy()
+    duplicates = scenario_df.duplicated("scenario_id", keep=False)
+    if duplicates.any():
+        duplicate_count = int(duplicates.sum())
+        raise ValueError(f"env_summary.parquet has {duplicate_count} duplicate scenario rows.")
+    return scenario_df
+
+
+def _antenna_features(antennas_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        antennas_df,
+        ["scenario_id", "antenna_id", "x", "y", "coverage_radius"],
+        "antennas.parquet",
+    )
+    grouped = antennas_df.groupby("scenario_id", sort=True)
+    features_df = grouped.agg(
+        antenna_layout_count=("antenna_id", "nunique"),
+        antenna_x_mean=("x", "mean"),
+        antenna_y_mean=("y", "mean"),
+        antenna_x_min=("x", "min"),
+        antenna_x_max=("x", "max"),
+        antenna_y_min=("y", "min"),
+        antenna_y_max=("y", "max"),
+        antenna_coverage_radius_mean_m=("coverage_radius", "mean"),
+        antenna_coverage_radius_min_m=("coverage_radius", "min"),
+        antenna_coverage_radius_max_m=("coverage_radius", "max"),
+    ).reset_index()
+    spread_df = grouped.agg(
+        antenna_x_std=("x", _std_or_zero),
+        antenna_y_std=("y", _std_or_zero),
+    ).reset_index()
+    return features_df.merge(spread_df, on="scenario_id", how="left", validate="one_to_one")
+
+
+def _link_features(links_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        links_df,
+        [
+            "scenario_id",
+            "target_id",
+            "antenna_id",
+            "distance_m",
+            "link_state",
+            "wall_blocker_count",
+            "human_blocker_count",
+            "total_blocker_count",
+        ],
+        "links.parquet",
+    )
+    grouped = links_df.groupby(KEY_COLUMNS, sort=True)
+    features_df = grouped.agg(
+        link_anchor_count=("antenna_id", "nunique"),
+        link_distance_mean_m=("distance_m", "mean"),
+        link_distance_min_m=("distance_m", "min"),
+        link_distance_max_m=("distance_m", "max"),
+        link_wall_blocker_mean=("wall_blocker_count", "mean"),
+        link_wall_blocker_max=("wall_blocker_count", "max"),
+        link_human_blocker_mean=("human_blocker_count", "mean"),
+        link_human_blocker_max=("human_blocker_count", "max"),
+        link_total_blocker_mean=("total_blocker_count", "mean"),
+        link_total_blocker_max=("total_blocker_count", "max"),
+    ).reset_index()
+    spread_df = grouped.agg(
+        link_distance_std_m=("distance_m", _std_or_zero),
+    ).reset_index()
+    state_counts = (
+        links_df.assign(
+            link_los_count=(links_df["link_state"].astype(str).str.upper() == "LOS").astype(int),
+            link_nlos_count=(links_df["link_state"].astype(str).str.upper() == "NLOS").astype(int),
+        )
+        .groupby(KEY_COLUMNS, sort=True)[["link_los_count", "link_nlos_count"]]
+        .sum()
+        .reset_index()
+    )
+    return (
+        features_df.merge(spread_df, on=KEY_COLUMNS, how="left", validate="one_to_one")
+        .merge(state_counts, on=KEY_COLUMNS, how="left", validate="one_to_one")
+    )
+
+
+def _rssi_features(rssi_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        rssi_df,
+        [
+            "scenario_id",
+            "target_id",
+            "signal_strength_dbm",
+            "path_loss_db_with_noise",
+            "path_loss_exponent_n",
+            "shadow_sigma_db",
+        ],
+        "links_rssi.parquet",
+    )
+    optional_cols = {
+        "obstacle_attenuation_db": 0.0,
+        "wall_attenuation_db": 0.0,
+        "human_attenuation_db": 0.0,
+    }
+    prepared_df = rssi_df.copy()
+    for column, default in optional_cols.items():
+        if column not in prepared_df.columns:
+            prepared_df[column] = default
+
+    grouped = prepared_df.groupby(KEY_COLUMNS, sort=True)
+    features_df = grouped.agg(
+        rssi_measurement_count=("signal_strength_dbm", "count"),
+        rssi_signal_mean_dbm=("signal_strength_dbm", "mean"),
+        rssi_signal_min_dbm=("signal_strength_dbm", "min"),
+        rssi_signal_max_dbm=("signal_strength_dbm", "max"),
+        rssi_path_loss_mean_db=("path_loss_db_with_noise", "mean"),
+        rssi_path_loss_min_db=("path_loss_db_with_noise", "min"),
+        rssi_path_loss_max_db=("path_loss_db_with_noise", "max"),
+        rssi_path_loss_exponent_mean=("path_loss_exponent_n", "mean"),
+        rssi_shadow_sigma_mean_db=("shadow_sigma_db", "mean"),
+        rssi_obstacle_attenuation_mean_db=("obstacle_attenuation_db", "mean"),
+        rssi_obstacle_attenuation_max_db=("obstacle_attenuation_db", "max"),
+        rssi_wall_attenuation_mean_db=("wall_attenuation_db", "mean"),
+        rssi_human_attenuation_mean_db=("human_attenuation_db", "mean"),
+    ).reset_index()
+    spread_df = grouped.agg(
+        rssi_signal_std_dbm=("signal_strength_dbm", _std_or_zero),
+        rssi_path_loss_std_db=("path_loss_db_with_noise", _std_or_zero),
+    ).reset_index()
+    return features_df.merge(spread_df, on=KEY_COLUMNS, how="left", validate="one_to_one")
+
+
+def _tdoa_features(tdoa_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        tdoa_df,
+        [
+            "scenario_id",
+            "target_id",
+            "observed_tdoa_ns",
+            "delta_distance_m",
+            "reference_distance_m",
+            "comparison_distance_m",
+            "tdoa_noise_sigma_ns",
+        ],
+        "links_tdoa.parquet",
+    )
+    grouped = tdoa_df.groupby(KEY_COLUMNS, sort=True)
+    features_df = grouped.agg(
+        tdoa_measurement_count=("observed_tdoa_ns", "count"),
+        tdoa_observed_mean_ns=("observed_tdoa_ns", "mean"),
+        tdoa_observed_min_ns=("observed_tdoa_ns", "min"),
+        tdoa_observed_max_ns=("observed_tdoa_ns", "max"),
+        tdoa_delta_distance_mean_m=("delta_distance_m", "mean"),
+        tdoa_delta_distance_min_m=("delta_distance_m", "min"),
+        tdoa_delta_distance_max_m=("delta_distance_m", "max"),
+        tdoa_reference_distance_mean_m=("reference_distance_m", "mean"),
+        tdoa_comparison_distance_mean_m=("comparison_distance_m", "mean"),
+        tdoa_noise_sigma_mean_ns=("tdoa_noise_sigma_ns", "mean"),
+    ).reset_index()
+    spread_df = grouped.agg(
+        tdoa_observed_std_ns=("observed_tdoa_ns", _std_or_zero),
+        tdoa_delta_distance_std_m=("delta_distance_m", _std_or_zero),
+    ).reset_index()
+    return features_df.merge(spread_df, on=KEY_COLUMNS, how="left", validate="one_to_one")
+
+
+def _doa_features(doa_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        doa_df,
+        [
+            "scenario_id",
+            "target_id",
+            "observed_bearing_rad",
+            "observed_doa_rad",
+            "doa_noise_sigma_deg",
+        ],
+        "links_doa.parquet",
+    )
+    prepared_df = doa_df.copy()
+    prepared_df["doa_observed_bearing_sin"] = np.sin(
+        prepared_df["observed_bearing_rad"].astype(float)
+    )
+    prepared_df["doa_observed_bearing_cos"] = np.cos(
+        prepared_df["observed_bearing_rad"].astype(float)
+    )
+    prepared_df["doa_observed_doa_sin"] = np.sin(
+        prepared_df["observed_doa_rad"].astype(float)
+    )
+    prepared_df["doa_observed_doa_cos"] = np.cos(
+        prepared_df["observed_doa_rad"].astype(float)
+    )
+
+    grouped = prepared_df.groupby(KEY_COLUMNS, sort=True)
+    return grouped.agg(
+        doa_measurement_count=("observed_bearing_rad", "count"),
+        doa_observed_bearing_sin_mean=("doa_observed_bearing_sin", "mean"),
+        doa_observed_bearing_cos_mean=("doa_observed_bearing_cos", "mean"),
+        doa_observed_doa_sin_mean=("doa_observed_doa_sin", "mean"),
+        doa_observed_doa_cos_mean=("doa_observed_doa_cos", "mean"),
+        doa_noise_sigma_mean_deg=("doa_noise_sigma_deg", "mean"),
+    ).reset_index()
+
+
+def _validate_one_row_per_target(dataset_df: pd.DataFrame) -> None:
+    duplicate_rows = dataset_df.duplicated(KEY_COLUMNS, keep=False)
+    if duplicate_rows.any():
+        duplicate_count = int(duplicate_rows.sum())
+        raise ValueError(f"ML dataset has {duplicate_count} duplicate scenario-target rows.")
+    if dataset_df[["target_x", "target_y"]].isna().any().any():
+        raise ValueError("ML dataset contains missing target_x or target_y labels.")
+
+
+def build_ml_dataset(data_dir: Union[str, Path]) -> pd.DataFrame:
+    env_summary_df = _read_table(data_dir, "env_summary", ["scenario_id", "env_type"])
+    antennas_df = _read_table(data_dir, "antennas", ["scenario_id", "antenna_id"])
+    links_df = _read_table(data_dir, "links", ["scenario_id", "target_id"])
+    rssi_df = _read_table(data_dir, "links_rssi", ["scenario_id", "target_id"])
+    tdoa_df = _read_table(data_dir, "links_tdoa", ["scenario_id", "target_id"])
+    doa_df = _read_table(data_dir, "links_doa", ["scenario_id", "target_id"])
+    estimates_df = _read_table(
+        data_dir,
+        "position_estimates",
+        ["scenario_id", "target_id", "target_x", "target_y"],
+    )
+
+    duplicate_estimates = estimates_df.duplicated(KEY_COLUMNS, keep=False)
+    if duplicate_estimates.any():
+        duplicate_count = int(duplicate_estimates.sum())
+        raise ValueError(
+            f"position_estimates.parquet has {duplicate_count} duplicate scenario-target rows."
+        )
+
+    dataset_df = estimates_df.copy()
+    dataset_df = dataset_df.merge(
+        _scenario_features(env_summary_df),
+        on="scenario_id",
+        how="left",
+        validate="many_to_one",
+    )
+    dataset_df = dataset_df.merge(
+        _antenna_features(antennas_df),
+        on="scenario_id",
+        how="left",
+        validate="many_to_one",
+    )
+    dataset_df = dataset_df.merge(
+        _link_features(links_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+    dataset_df = dataset_df.merge(
+        _rssi_features(rssi_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+    dataset_df = dataset_df.merge(
+        _tdoa_features(tdoa_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+    dataset_df = dataset_df.merge(
+        _doa_features(doa_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+
+    _validate_one_row_per_target(dataset_df)
+    return dataset_df.copy()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build one labelled ML dataset row per scenario-target pair."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default="generated_network_scenarios",
+        help="Directory containing generated parquet tables.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output parquet path. Default: <data-dir>/ml_dataset.parquet",
+    )
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    output_path = Path(args.output) if args.output else data_dir / "ml_dataset.parquet"
+    ml_dataset_df = build_ml_dataset(data_dir)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    ml_dataset_df.to_parquet(output_path, index=False)
+
+    print(f"Wrote {len(ml_dataset_df)} labelled ML rows to {output_path}")
+    print("Labels: target_x, target_y")
+
+
+if __name__ == "__main__":
+    main()

--- a/Data Generation/position_estimation.py
+++ b/Data Generation/position_estimation.py
@@ -1,0 +1,626 @@
+"""
+CONVENTIONAL POSITION ESTIMATION
+--------------------------------
+
+Build target-position estimates from the RSSI, TDOA, and DOA/AOA measurement
+tables produced by the data-generation pipeline.
+
+Input tables:
+- links.parquet
+- links_rssi.parquet
+- links_tdoa.parquet
+- links_doa.parquet
+
+Output table:
+- position_estimates.parquet by default
+
+The output contains one row per scenario-target pair. It keeps the ground-truth
+target coordinates as labels and adds conventional method estimates plus error
+metrics, ready to be merged into an ML feature table.
+
+Usage examples:
+python3 "Data Generation/position_estimation.py" --data-dir "generated_network_scenarios"
+python3 "Data Generation/position_estimation.py" \
+  --data-dir "Data Generation/generated_network_scenarios" \
+  --output "Data Generation/generated_network_scenarios/position_estimates.parquet"
+
+@author: Giuliana Emberson
+@date: 7th of May 2026
+
+"""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Tuple, Union
+import numpy as np
+import pandas as pd
+
+
+KEY_COLUMNS = ["scenario_id", "target_id"]
+DEFAULT_REFERENCE_DISTANCE_M = 1.0
+EPSILON = 1e-9
+
+
+def _require_columns(df: pd.DataFrame, required: Iterable[str], table_name: str) -> None:
+    missing = set(required).difference(df.columns)
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(f"{table_name} is missing required columns: {missing_list}")
+
+
+def _read_table(data_dir: Union[str, Path], table_name: str, required: Iterable[str]) -> pd.DataFrame:
+    path = Path(data_dir) / f"{table_name}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Missing {path}. Run the corresponding data-generation stage first."
+        )
+    df = pd.read_parquet(path)
+    _require_columns(df, required, f"{table_name}.parquet")
+    return df
+
+
+def _target_truth_from_links(links_df: pd.DataFrame) -> pd.DataFrame:
+    target_cols = [
+        "scenario_id",
+        "target_id",
+        "target_label",
+        "target_x",
+        "target_y",
+        "target_cell_id",
+        "target_row_idx",
+        "target_col_idx",
+        "target_space_type",
+        "target_room_id",
+        "target_room_type",
+        "target_patio_id",
+    ]
+    available_cols = [column for column in target_cols if column in links_df.columns]
+    target_df = links_df[available_cols].drop_duplicates().copy()
+    duplicate_keys = target_df.duplicated(KEY_COLUMNS, keep=False)
+    if duplicate_keys.any():
+        duplicate_count = int(duplicate_keys.sum())
+        raise ValueError(
+            f"links.parquet contains {duplicate_count} conflicting target-label rows."
+        )
+    return target_df
+
+
+def _least_squares_range_position(
+    anchors: np.ndarray,
+    ranges_m: np.ndarray,
+    weights: Optional[np.ndarray] = None,
+) -> Tuple[Optional[np.ndarray], Optional[float], int]:
+    valid = (
+        np.isfinite(anchors).all(axis=1)
+        & np.isfinite(ranges_m)
+        & (ranges_m > 0)
+    )
+    if weights is not None:
+        valid &= np.isfinite(weights) & (weights > 0)
+
+    anchors = anchors[valid]
+    ranges_m = ranges_m[valid]
+    resolved_weights = weights[valid] if weights is not None else None
+    anchor_count = len(anchors)
+    if anchor_count < 3:
+        return None, None, anchor_count
+
+    ref_idx = int(np.argmin(ranges_m))
+    ref_anchor = anchors[ref_idx]
+    ref_range = ranges_m[ref_idx]
+    other_mask = np.arange(anchor_count) != ref_idx
+    other_anchors = anchors[other_mask]
+    other_ranges = ranges_m[other_mask]
+
+    a_matrix = 2.0 * (other_anchors - ref_anchor)
+    b_vector = (
+        (ref_range**2)
+        - (other_ranges**2)
+        + np.sum(other_anchors**2, axis=1)
+        - np.sum(ref_anchor**2)
+    )
+
+    if resolved_weights is not None:
+        other_weights = np.sqrt(resolved_weights[other_mask])
+        a_matrix = a_matrix * other_weights[:, np.newaxis]
+        b_vector = b_vector * other_weights
+
+    try:
+        solution, _, rank, _ = np.linalg.lstsq(a_matrix, b_vector, rcond=None)
+    except np.linalg.LinAlgError:
+        return None, None, anchor_count
+
+    if rank < 2 or not np.isfinite(solution).all():
+        return None, None, anchor_count
+
+    position = _refine_range_position(solution, anchors, ranges_m, resolved_weights)
+    residuals = np.linalg.norm(position - anchors, axis=1) - ranges_m
+    rmse = float(np.sqrt(np.mean(residuals**2)))
+    return position, rmse, anchor_count
+
+
+def _refine_range_position(
+    initial_position: np.ndarray,
+    anchors: np.ndarray,
+    ranges_m: np.ndarray,
+    weights: Optional[np.ndarray],
+    *,
+    max_iterations: int = 25,
+) -> np.ndarray:
+    position = np.array(initial_position, dtype=float)
+    sqrt_weights = np.sqrt(weights) if weights is not None else None
+
+    def objective(candidate: np.ndarray) -> float:
+        residuals = np.linalg.norm(candidate - anchors, axis=1) - ranges_m
+        if sqrt_weights is not None:
+            residuals = residuals * sqrt_weights
+        return float(np.mean(residuals**2))
+
+    best_score = objective(position)
+
+    for _ in range(max_iterations):
+        deltas = position - anchors
+        distances = np.linalg.norm(deltas, axis=1)
+        safe_distances = np.maximum(distances, EPSILON)
+        residuals = distances - ranges_m
+        jacobian = deltas / safe_distances[:, np.newaxis]
+
+        if sqrt_weights is not None:
+            weighted_jacobian = jacobian * sqrt_weights[:, np.newaxis]
+            weighted_residuals = residuals * sqrt_weights
+        else:
+            weighted_jacobian = jacobian
+            weighted_residuals = residuals
+
+        try:
+            step, _, rank, _ = np.linalg.lstsq(
+                weighted_jacobian,
+                -weighted_residuals,
+                rcond=None,
+            )
+        except np.linalg.LinAlgError:
+            break
+
+        if rank < 2 or not np.isfinite(step).all():
+            break
+
+        accepted = False
+        for damping in (1.0, 0.5, 0.25, 0.1, 0.05, 0.01):
+            candidate = position + (step * damping)
+            if not np.isfinite(candidate).all():
+                continue
+            candidate_score = objective(candidate)
+            if candidate_score <= best_score:
+                position = candidate
+                best_score = candidate_score
+                accepted = True
+                break
+
+        if not accepted:
+            break
+
+        if np.linalg.norm(step) < 1e-6:
+            break
+
+    return position
+
+
+def _position_error_m(
+    est_x: object,
+    est_y: object,
+    target_x: object,
+    target_y: object,
+) -> float:
+    values = np.array([est_x, est_y, target_x, target_y], dtype=float)
+    if not np.isfinite(values).all():
+        return float("nan")
+    return float(np.hypot(values[0] - values[2], values[1] - values[3]))
+
+
+def _rssi_range_estimates_m(group: pd.DataFrame) -> np.ndarray:
+    reference_distance = (
+        group["reference_distance_m"].astype(float).to_numpy()
+        if "reference_distance_m" in group.columns
+        else np.full(len(group), DEFAULT_REFERENCE_DISTANCE_M, dtype=float)
+    )
+    path_loss_db = (
+        group["initial_signal_strength_dbm"].astype(float).to_numpy()
+        - group["signal_strength_dbm"].astype(float).to_numpy()
+    )
+    obstacle_loss_db = (
+        group["obstacle_attenuation_db"].astype(float).to_numpy()
+        if "obstacle_attenuation_db" in group.columns
+        else np.zeros(len(group), dtype=float)
+    )
+    exponent_n = group["path_loss_exponent_n"].astype(float).to_numpy()
+    compensated_loss_db = path_loss_db - obstacle_loss_db
+    exponent = compensated_loss_db / np.maximum(10.0 * exponent_n, EPSILON)
+    exponent = np.clip(exponent, -6.0, 6.0)
+    return reference_distance * np.power(10.0, exponent)
+
+
+def estimate_rssi_positions(rssi_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        rssi_df,
+        [
+            "scenario_id",
+            "target_id",
+            "antenna_x",
+            "antenna_y",
+            "signal_strength_dbm",
+            "initial_signal_strength_dbm",
+            "path_loss_exponent_n",
+        ],
+        "links_rssi.parquet",
+    )
+
+    rows = []
+    for (scenario_id, target_id), group in rssi_df.groupby(KEY_COLUMNS, sort=True):
+        anchors = group[["antenna_x", "antenna_y"]].astype(float).to_numpy()
+        ranges_m = _rssi_range_estimates_m(group)
+        sigma = (
+            group["shadow_sigma_db"].astype(float).to_numpy()
+            if "shadow_sigma_db" in group.columns
+            else np.ones(len(group), dtype=float)
+        )
+        weights = 1.0 / np.maximum(sigma, EPSILON) ** 2
+        position, residual_rmse, anchor_count = _least_squares_range_position(
+            anchors,
+            ranges_m,
+            weights=weights,
+        )
+        rows.append(
+            {
+                "scenario_id": scenario_id,
+                "target_id": target_id,
+                "rssi_anchor_count": anchor_count,
+                "rssi_est_x": float(position[0]) if position is not None else np.nan,
+                "rssi_est_y": float(position[1]) if position is not None else np.nan,
+                "rssi_residual_rmse_m": residual_rmse,
+                "rssi_success": position is not None,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def _least_squares_tdoa_position(
+    reference_anchor: np.ndarray,
+    comparison_anchors: np.ndarray,
+    delta_distances_m: np.ndarray,
+) -> Tuple[Optional[np.ndarray], Optional[float], int]:
+    valid = (
+        np.isfinite(comparison_anchors).all(axis=1)
+        & np.isfinite(delta_distances_m)
+        & np.isfinite(reference_anchor).all()
+    )
+    comparison_anchors = comparison_anchors[valid]
+    delta_distances_m = delta_distances_m[valid]
+    anchor_count = len(comparison_anchors) + 1
+    if len(comparison_anchors) < 3:
+        return None, None, anchor_count
+
+    x0, y0 = reference_anchor
+    xi = comparison_anchors[:, 0]
+    yi = comparison_anchors[:, 1]
+    delta = delta_distances_m
+
+    a_matrix = np.column_stack(
+        [
+            2.0 * (x0 - xi),
+            2.0 * (y0 - yi),
+            -2.0 * delta,
+        ]
+    )
+    b_vector = (delta**2) - (xi**2) + (x0**2) - (yi**2) + (y0**2)
+
+    initial = np.mean(np.vstack([reference_anchor, comparison_anchors]), axis=0)
+    try:
+        solution, _, rank, _ = np.linalg.lstsq(a_matrix, b_vector, rcond=None)
+        if rank >= 2 and np.isfinite(solution[:2]).all():
+            initial = solution[:2]
+    except np.linalg.LinAlgError:
+        pass
+
+    position = _refine_tdoa_position(
+        initial,
+        reference_anchor,
+        comparison_anchors,
+        delta_distances_m,
+    )
+    if position is None:
+        return None, None, anchor_count
+
+    reference_distance = np.linalg.norm(position - reference_anchor)
+    comparison_distances = np.linalg.norm(position - comparison_anchors, axis=1)
+    residuals = (comparison_distances - reference_distance) - delta_distances_m
+    rmse = float(np.sqrt(np.mean(residuals**2)))
+    return position, rmse, anchor_count
+
+
+def _refine_tdoa_position(
+    initial_position: np.ndarray,
+    reference_anchor: np.ndarray,
+    comparison_anchors: np.ndarray,
+    delta_distances_m: np.ndarray,
+    *,
+    max_iterations: int = 35,
+) -> Optional[np.ndarray]:
+    position = np.array(initial_position, dtype=float)
+
+    for _ in range(max_iterations):
+        ref_delta = position - reference_anchor
+        ref_distance = max(float(np.linalg.norm(ref_delta)), EPSILON)
+        comp_delta = position - comparison_anchors
+        comp_distances = np.maximum(np.linalg.norm(comp_delta, axis=1), EPSILON)
+
+        residuals = (comp_distances - ref_distance) - delta_distances_m
+        jacobian = (
+            comp_delta / comp_distances[:, np.newaxis]
+            - ref_delta / ref_distance
+        )
+
+        try:
+            step, _, rank, _ = np.linalg.lstsq(jacobian, -residuals, rcond=None)
+        except np.linalg.LinAlgError:
+            return None
+
+        if rank < 2 or not np.isfinite(step).all():
+            return None
+
+        position = position + step
+        if np.linalg.norm(step) < 1e-6:
+            break
+
+    return position if np.isfinite(position).all() else None
+
+
+def estimate_tdoa_positions(tdoa_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        tdoa_df,
+        [
+            "scenario_id",
+            "target_id",
+            "reference_antenna_x",
+            "reference_antenna_y",
+            "comparison_antenna_x",
+            "comparison_antenna_y",
+            "observed_tdoa_ns",
+            "propagation_speed_m_per_s",
+        ],
+        "links_tdoa.parquet",
+    )
+
+    rows = []
+    for (scenario_id, target_id), group in tdoa_df.groupby(KEY_COLUMNS, sort=True):
+        first = group.iloc[0]
+        reference_anchor = np.array(
+            [first["reference_antenna_x"], first["reference_antenna_y"]],
+            dtype=float,
+        )
+        comparison_anchors = group[
+            ["comparison_antenna_x", "comparison_antenna_y"]
+        ].astype(float).to_numpy()
+        propagation_speed = group["propagation_speed_m_per_s"].astype(float).to_numpy()
+        delta_distances = (
+            group["observed_tdoa_ns"].astype(float).to_numpy()
+            * propagation_speed
+            / 1e9
+        )
+        position, residual_rmse, anchor_count = _least_squares_tdoa_position(
+            reference_anchor,
+            comparison_anchors,
+            delta_distances,
+        )
+        rows.append(
+            {
+                "scenario_id": scenario_id,
+                "target_id": target_id,
+                "tdoa_anchor_count": anchor_count,
+                "tdoa_est_x": float(position[0]) if position is not None else np.nan,
+                "tdoa_est_y": float(position[1]) if position is not None else np.nan,
+                "tdoa_residual_rmse_m": residual_rmse,
+                "tdoa_success": position is not None,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def _least_squares_doa_position(
+    anchors: np.ndarray,
+    bearings_rad: np.ndarray,
+    weights: Optional[np.ndarray] = None,
+) -> Tuple[Optional[np.ndarray], Optional[float], int]:
+    valid = np.isfinite(anchors).all(axis=1) & np.isfinite(bearings_rad)
+    if weights is not None:
+        valid &= np.isfinite(weights) & (weights > 0)
+
+    anchors = anchors[valid]
+    bearings_rad = bearings_rad[valid]
+    resolved_weights = weights[valid] if weights is not None else None
+    anchor_count = len(anchors)
+    if anchor_count < 2:
+        return None, None, anchor_count
+
+    normals = np.column_stack([-np.sin(bearings_rad), np.cos(bearings_rad)])
+    b_vector = np.sum(normals * anchors, axis=1)
+    a_matrix = normals
+
+    if resolved_weights is not None:
+        sqrt_weights = np.sqrt(resolved_weights)
+        a_matrix = a_matrix * sqrt_weights[:, np.newaxis]
+        b_vector = b_vector * sqrt_weights
+
+    try:
+        solution, _, rank, _ = np.linalg.lstsq(a_matrix, b_vector, rcond=None)
+    except np.linalg.LinAlgError:
+        return None, None, anchor_count
+
+    if rank < 2 or not np.isfinite(solution).all():
+        return None, None, anchor_count
+
+    line_residuals = normals @ solution - np.sum(normals * anchors, axis=1)
+    rmse = float(np.sqrt(np.mean(line_residuals**2)))
+    return solution, rmse, anchor_count
+
+
+def estimate_doa_positions(doa_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        doa_df,
+        [
+            "scenario_id",
+            "target_id",
+            "antenna_x",
+            "antenna_y",
+            "observed_bearing_rad",
+        ],
+        "links_doa.parquet",
+    )
+
+    rows = []
+    for (scenario_id, target_id), group in doa_df.groupby(KEY_COLUMNS, sort=True):
+        anchors = group[["antenna_x", "antenna_y"]].astype(float).to_numpy()
+        bearings = group["observed_bearing_rad"].astype(float).to_numpy()
+        sigma = (
+            group["doa_noise_sigma_rad"].astype(float).to_numpy()
+            if "doa_noise_sigma_rad" in group.columns
+            else np.ones(len(group), dtype=float)
+        )
+        weights = 1.0 / np.maximum(sigma, EPSILON) ** 2
+        position, residual_rmse, anchor_count = _least_squares_doa_position(
+            anchors,
+            bearings,
+            weights=weights,
+        )
+        rows.append(
+            {
+                "scenario_id": scenario_id,
+                "target_id": target_id,
+                "doa_anchor_count": anchor_count,
+                "doa_est_x": float(position[0]) if position is not None else np.nan,
+                "doa_est_y": float(position[1]) if position is not None else np.nan,
+                "doa_residual_rmse_m": residual_rmse,
+                "doa_success": position is not None,
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def build_position_estimates(data_dir: Union[str, Path]) -> pd.DataFrame:
+    links_df = _read_table(
+        data_dir,
+        "links",
+        [
+            "scenario_id",
+            "target_id",
+            "target_x",
+            "target_y",
+            "antenna_id",
+            "distance_m",
+        ],
+    )
+    rssi_df = _read_table(data_dir, "links_rssi", ["scenario_id", "target_id"])
+    tdoa_df = _read_table(data_dir, "links_tdoa", ["scenario_id", "target_id"])
+    doa_df = _read_table(data_dir, "links_doa", ["scenario_id", "target_id"])
+
+    estimates_df = _target_truth_from_links(links_df)
+    estimates_df = estimates_df.merge(
+        estimate_rssi_positions(rssi_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+    estimates_df = estimates_df.merge(
+        estimate_tdoa_positions(tdoa_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+    estimates_df = estimates_df.merge(
+        estimate_doa_positions(doa_df),
+        on=KEY_COLUMNS,
+        how="left",
+        validate="one_to_one",
+    )
+
+    for method in ("rssi", "tdoa", "doa"):
+        estimates_df[f"{method}_error_m"] = [
+            _position_error_m(est_x, est_y, target_x, target_y)
+            for est_x, est_y, target_x, target_y in zip(
+                estimates_df[f"{method}_est_x"],
+                estimates_df[f"{method}_est_y"],
+                estimates_df["target_x"],
+                estimates_df["target_y"],
+            )
+        ]
+
+    ordered_cols = [
+        "scenario_id",
+        "target_id",
+        "target_label",
+        "target_x",
+        "target_y",
+        "target_cell_id",
+        "target_row_idx",
+        "target_col_idx",
+        "target_space_type",
+        "target_room_id",
+        "target_room_type",
+        "target_patio_id",
+        "rssi_est_x",
+        "rssi_est_y",
+        "rssi_error_m",
+        "rssi_residual_rmse_m",
+        "rssi_anchor_count",
+        "rssi_success",
+        "tdoa_est_x",
+        "tdoa_est_y",
+        "tdoa_error_m",
+        "tdoa_residual_rmse_m",
+        "tdoa_anchor_count",
+        "tdoa_success",
+        "doa_est_x",
+        "doa_est_y",
+        "doa_error_m",
+        "doa_residual_rmse_m",
+        "doa_anchor_count",
+        "doa_success",
+    ]
+    return estimates_df[[column for column in ordered_cols if column in estimates_df.columns]].copy()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Estimate target positions from RSSI, TDOA, and DOA measurement tables."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default="generated_network_scenarios",
+        help="Directory containing generated parquet tables.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output parquet path. Default: <data-dir>/position_estimates.parquet",
+    )
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    output_path = Path(args.output) if args.output else data_dir / "position_estimates.parquet"
+    position_estimates_df = build_position_estimates(data_dir)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    position_estimates_df.to_parquet(output_path, index=False)
+
+    print(f"Wrote {len(position_estimates_df)} position estimate rows to {output_path}")
+    for method in ("rssi", "tdoa", "doa"):
+        success_count = int(position_estimates_df[f"{method}_success"].fillna(False).sum())
+        print(f"{method.upper()} successful estimates: {success_count}/{len(position_estimates_df)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Data Generation/validate_generation_outputs.py
+++ b/Data Generation/validate_generation_outputs.py
@@ -1,0 +1,256 @@
+"""
+DATA GENERATION OUTPUT VALIDATOR
+--------------------------------
+
+Validate the generated parquet tables before starting the ML pipeline.
+
+Checks:
+- Shared link row counts match target_count * antenna_count.
+- RSSI and DOA measurement row counts match links.parquet.
+- TDOA row counts match target_count * (antenna_count - 1).
+- Required measurement columns exist and are populated.
+- position_estimates.parquet and ml_dataset.parquet contain one row per target.
+- ML labels and conventional estimate/error columns are present.
+
+Usage:
+python3 "Data Generation/validate_generation_outputs.py" --data-dir "generated_network_scenarios"
+
+@author: Giuliana Emberson
+@date: 7th of May 2026
+
+"""
+
+from __future__ import annotations
+import argparse
+from pathlib import Path
+from typing import Iterable, Union
+import pandas as pd
+
+
+KEY_COLUMNS = ["scenario_id", "target_id"]
+
+
+def _require_columns(df: pd.DataFrame, required: Iterable[str], table_name: str) -> None:
+    missing = set(required).difference(df.columns)
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(f"{table_name} is missing required columns: {missing_list}")
+
+
+def _read_table(data_dir: Union[str, Path], table_name: str, required: Iterable[str]) -> pd.DataFrame:
+    path = Path(data_dir) / f"{table_name}.parquet"
+    if not path.exists():
+        raise FileNotFoundError(f"Missing required table: {path}")
+    df = pd.read_parquet(path)
+    _require_columns(df, required, f"{table_name}.parquet")
+    return df
+
+
+def _check_no_missing(df: pd.DataFrame, columns: Iterable[str], table_name: str) -> None:
+    columns = list(columns)
+    missing = df[columns].isna().sum()
+    bad = missing[missing > 0]
+    if not bad.empty:
+        details = ", ".join(f"{column}={count}" for column, count in bad.items())
+        raise ValueError(f"{table_name} has missing values in required columns: {details}")
+
+
+def _check_unique_targets(df: pd.DataFrame, table_name: str) -> None:
+    duplicates = df.duplicated(KEY_COLUMNS, keep=False)
+    if duplicates.any():
+        duplicate_count = int(duplicates.sum())
+        raise ValueError(f"{table_name} has {duplicate_count} duplicate scenario-target rows.")
+
+
+def _expected_counts(env_summary_df: pd.DataFrame) -> pd.DataFrame:
+    _require_columns(
+        env_summary_df,
+        ["scenario_id", "target_count", "antenna_count"],
+        "env_summary.parquet",
+    )
+    counts_df = env_summary_df[["scenario_id", "target_count", "antenna_count"]].copy()
+    counts_df["expected_link_count"] = (
+        counts_df["target_count"].astype(int) * counts_df["antenna_count"].astype(int)
+    )
+    counts_df["expected_tdoa_count"] = (
+        counts_df["target_count"].astype(int)
+        * (counts_df["antenna_count"].astype(int) - 1)
+    )
+    return counts_df
+
+
+def _check_count_by_scenario(
+    actual_df: pd.DataFrame,
+    counts_df: pd.DataFrame,
+    *,
+    expected_column: str,
+    table_name: str,
+) -> None:
+    actual_counts = (
+        actual_df.groupby("scenario_id", sort=True)
+        .size()
+        .rename("actual_count")
+        .reset_index()
+    )
+    merged_df = counts_df[["scenario_id", expected_column]].merge(
+        actual_counts,
+        on="scenario_id",
+        how="left",
+        validate="one_to_one",
+    )
+    merged_df["actual_count"] = merged_df["actual_count"].fillna(0).astype(int)
+    bad_df = merged_df[merged_df["actual_count"] != merged_df[expected_column]]
+    if not bad_df.empty:
+        first_bad = bad_df.iloc[0]
+        raise ValueError(
+            f"{table_name} count mismatch for {first_bad['scenario_id']}: "
+            f"expected {int(first_bad[expected_column])}, got {int(first_bad['actual_count'])}."
+        )
+
+
+def validate_generation_outputs(data_dir: Union[str, Path]) -> None:
+    env_summary_df = _read_table(
+        data_dir,
+        "env_summary",
+        ["scenario_id", "target_count", "antenna_count"],
+    )
+    links_df = _read_table(data_dir, "links", ["scenario_id", "target_id"])
+    rssi_df = _read_table(
+        data_dir,
+        "links_rssi",
+        ["scenario_id", "target_id", "signal_strength_dbm", "path_loss_db_with_noise"],
+    )
+    tdoa_df = _read_table(
+        data_dir,
+        "links_tdoa",
+        ["scenario_id", "target_id", "observed_tdoa_ns"],
+    )
+    doa_df = _read_table(
+        data_dir,
+        "links_doa",
+        ["scenario_id", "target_id", "observed_doa_deg", "observed_bearing_deg"],
+    )
+    estimates_df = _read_table(
+        data_dir,
+        "position_estimates",
+        [
+            "scenario_id",
+            "target_id",
+            "target_x",
+            "target_y",
+            "rssi_est_x",
+            "rssi_est_y",
+            "rssi_error_m",
+            "tdoa_est_x",
+            "tdoa_est_y",
+            "tdoa_error_m",
+            "doa_est_x",
+            "doa_est_y",
+            "doa_error_m",
+        ],
+    )
+    ml_dataset_df = _read_table(
+        data_dir,
+        "ml_dataset",
+        [
+            "scenario_id",
+            "target_id",
+            "target_x",
+            "target_y",
+            "rssi_est_x",
+            "rssi_est_y",
+            "rssi_error_m",
+            "tdoa_est_x",
+            "tdoa_est_y",
+            "tdoa_error_m",
+            "doa_est_x",
+            "doa_est_y",
+            "doa_error_m",
+        ],
+    )
+
+    counts_df = _expected_counts(env_summary_df)
+    _check_count_by_scenario(
+        links_df,
+        counts_df,
+        expected_column="expected_link_count",
+        table_name="links.parquet",
+    )
+    _check_count_by_scenario(
+        rssi_df,
+        counts_df,
+        expected_column="expected_link_count",
+        table_name="links_rssi.parquet",
+    )
+    _check_count_by_scenario(
+        doa_df,
+        counts_df,
+        expected_column="expected_link_count",
+        table_name="links_doa.parquet",
+    )
+    _check_count_by_scenario(
+        tdoa_df,
+        counts_df,
+        expected_column="expected_tdoa_count",
+        table_name="links_tdoa.parquet",
+    )
+
+    _check_no_missing(
+        rssi_df,
+        ["signal_strength_dbm", "path_loss_db_with_noise"],
+        "links_rssi.parquet",
+    )
+    _check_no_missing(tdoa_df, ["observed_tdoa_ns"], "links_tdoa.parquet")
+    _check_no_missing(
+        doa_df,
+        ["observed_doa_deg", "observed_bearing_deg"],
+        "links_doa.parquet",
+    )
+
+    _check_unique_targets(estimates_df, "position_estimates.parquet")
+    _check_unique_targets(ml_dataset_df, "ml_dataset.parquet")
+    expected_target_total = int(counts_df["target_count"].sum())
+    if len(estimates_df) != expected_target_total:
+        raise ValueError(
+            f"position_estimates.parquet row count mismatch: "
+            f"expected {expected_target_total}, got {len(estimates_df)}."
+        )
+    if len(ml_dataset_df) != expected_target_total:
+        raise ValueError(
+            f"ml_dataset.parquet row count mismatch: "
+            f"expected {expected_target_total}, got {len(ml_dataset_df)}."
+        )
+
+    _check_no_missing(estimates_df, ["target_x", "target_y"], "position_estimates.parquet")
+    _check_no_missing(ml_dataset_df, ["target_x", "target_y"], "ml_dataset.parquet")
+
+    for method in ("rssi", "tdoa", "doa"):
+        success_col = f"{method}_success"
+        if success_col in estimates_df.columns:
+            successful_df = estimates_df[estimates_df[success_col].fillna(False)]
+            if not successful_df.empty:
+                _check_no_missing(
+                    successful_df,
+                    [f"{method}_est_x", f"{method}_est_y", f"{method}_error_m"],
+                    "position_estimates.parquet",
+                )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate generated data, measurement, estimate, and ML dataset tables."
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=str,
+        default="generated_network_scenarios",
+        help="Directory containing generated parquet tables.",
+    )
+    args = parser.parse_args()
+
+    validate_generation_outputs(args.data_dir)
+    print(f"Validation passed for {args.data_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ This project aims to address the limitations of GPS by developing a machine lear
 signals and instead leverages communication between devices within the same 5 GHz
 localised network. To achieve this, the project will evaluate and compare signal-based,
 direction-based and time-based indoor positioning methods [2], under emulated
-conditions. A key assumption in this project is that multi-path interference will not
-significantly affect localisation performance. Therefore, while multi-path propagation
-will be considered, the system will focus only on the strongest received signal when
-estimating position. Moreover, the specific problem addressed in this project is
-whether a machine learning model can outperform conventional indoor positioning
-methods by learning patterns and compensating for environmental conditions that
-arise in both indoor and outdoor propagation environments, such as noise,
-interference, non-line-of-sight (NLOS), and line-of-sight (LOS) [1].
+conditions. RSSI, TDOA, and DOA/AOA measurements are generated under indoor
+and outdoor scenarios with LOS/NLOS link states, obstacle interactions, and
+measurement noise. Multipath propagation is not explicitly simulated in this
+implementation; instead, obstruction effects are approximated through LOS/NLOS
+classification, blocker counts, environment-dependent noise, and optional RSSI
+obstacle attenuation. The specific problem addressed in this project is whether a
+machine learning model can outperform or refine conventional indoor positioning
+methods by learning patterns caused by environmental conditions in both indoor
+and outdoor propagation environments [1].
 
 This problem provides a sufficient challenge for an undergraduate dissertation due to the mathematical
 complexity of using device positioning methods and the intricacies of generating
@@ -54,8 +55,9 @@ network environments will be emulated by randomly generating scenario
 parameters and constraints. Each environment scenario will include all data
 required to perform positioning estimations. This includes generating the exact
 (ground-truth) position of the target device and other devices in the network,
-obstacles, material attenuation coefficients, noise, interference, signal strength
-measurements, etc.
+floor-plan obstacles, valid target locations, antenna-target distances, LOS/NLOS
+link states, obstacle blocker counts, and the scenario context required for
+method-specific RSSI, TDOA, and DOA/AOA measurement generation.
 
 - **Risk**: Failing to represent realistic network conditions or introducing bias by lacking enough variation in the generated data.
 
@@ -70,14 +72,15 @@ and relevance [1].
 The generated network environments will be
 used to produce multiple position estimates. For each network scenario, the
 position of the same target device will be calculated using three indoor
-positioning methods: Received Signal Strength Indicators (RSSI), Time of
-Arrival (TOA), and Angle of Arrival (AOA).
+positioning methods: Received Signal Strength Indicators (RSSI), Time Difference
+of Arrival (TDOA), and Direction/Angle of Arrival (DOA/AOA).
 
 - **Risk**: Emulated environments may oversimplify network conditions
 affecting the performance of some positioning methods more than
 others.
 - **Mitigation**: Attenuation, noise, and LOS/NLOS conditions will be
-incorporated to improve dataset realism [1].
+approximated through blocker-aware RSSI attenuation, measurement noise, and
+LOS/NLOS link classification to improve dataset realism [1].
 
 <br>
 


### PR DESCRIPTION
### Changes

Added conventional position estimation in `position_estimation.py`:

- RSSI range inversion + weighted multilateration.
  - TDOA multilateration from observed time differences.
  - DOA/AOA least-squares bearing intersection.
  - Outputs `position_estimates.parquet` with `rssi_est_x/y`, `tdoa_est_x/y`, `doa_est_x/y`, success flags, residuals, and error metrics.

- Added labelled ML dataset builder in create_ml_dataset.py:
  - Builds one row per `(scenario_id, target_id)`.
  - Keeps labels `target_x, target_y`.
  - Merges scenario, antenna, link, RSSI, TDOA, DOA, and conventional estimate features.
  - Outputs `ml_dataset.parquet`.

- Added validation script in `validate_generation_outputs.py`:
  - Checks expected row counts.
  - Checks measurement columns.
  - Checks one ML row per target.
  - Checks labels and conventional estimate/error columns.

- Updated RSSI output in `RSSI_envs.py` to include `reference_distance_m`, so RSSI range estimation is explicit.

- Updated project wording in `README.md` so it no longer overclaims material attenuation or explicit multipath simulation.

- Expanded `Data Generation/README.md` with the full pipeline, output tables, and attenuation scope.

### How To Run The Full Pipeline (Up to this point):

```bash
python3 "Data Generation/create_network_envs.py" --count 1 --seed 7 --output-dir "generated_network_scenarios"
python3 "Data Generation/RSSI/RSSI_envs.py" --data-dir "generated_network_scenarios" --seed 7
python3 "Data Generation/TDOA/TDOA_envs.py" --data-dir "generated_network_scenarios" --seed 7
python3 "Data Generation/DOA/DOA_envs.py" --data-dir "generated_network_scenarios" --seed 7
python3 "Data Generation/position_estimation.py" --data-dir "generated_network_scenarios"
python3 "Data Generation/create_ml_dataset.py" --data-dir "generated_network_scenarios"
python3 "Data Generation/validate_generation_outputs.py" --data-dir "generated_network_scenarios"

```